### PR TITLE
feat(AMG-14) fix Talend API Microgateway chart deployment

### DIFF
--- a/index.yaml
+++ b/index.yaml
@@ -2,8 +2,8 @@ apiVersion: v1
 entries:
   talend-api-microgateway:
   - apiVersion: v1
-    appVersion: 1.4
-    created: 2019-12-09T08:40:49.2912238+01:00
+    appVersion: "1.4"
+    created: 2019-12-09T11:40:49.2912238+01:00
     description: A Helm chart for Talend API Microgateway to be run along with Talend
       Remote Engine for Pipelines
     digest: 93bc88cecd62c86f267c8bfff4cb92addbc4d5c5f9742e4237a24eecd82f2e91


### PR DESCRIPTION
You can test with 
`helm repo add test https://raw.githubusercontent.com/Talend/helm-charts-public/elogeart/feat/AMG-14_talend_api_microgateway_helm_chart` which works
whereas this one fails: 
`https://raw.githubusercontent.com/Talend/helm-charts-public/d9b59fcc74182ecaed0b975fb0c437cdacf352ff`
with error `Error: Looks like "https://raw.githubusercontent.com/Talend/helm-charts-public/d9b59fcc74182ecaed0b975fb0c437cdacf352ff" is not a valid chart repository or cannot be reached: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go struct field ChartVersion.entries.appVersion of type string`