### PR TITLE
feat(gateway):add incubator back (empty)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
       run: helm repo add incubator https://raw.githubusercontent.com/Talend/helm-charts-public/$GITHUB_SHA/incubator
     - name: install helm repo stable
       run: helm repo add stable https://raw.githubusercontent.com/Talend/helm-charts-public/$GITHUB_SHA/stable
+    - name: install helm repo released
+      run: helm repo add stable https://raw.githubusercontent.com/Talend/helm-charts-public/$GITHUB_SHA/released
 
     # perform some update, I think this is not required as the previous add should detect issues but it does not cost much :)
     - name: update the test helm repo

--- a/incubator/index.yaml
+++ b/incubator/index.yaml
@@ -1,0 +1,3 @@
+apiVersion: v1
+entries:
+generated: "2020-01-15T11:57:14.010799+01:00"


### PR DESCRIPTION
I had to rename the incubator folder to released. 
But incubator is still required for Talend helm plugin.