### PR TITLE
fix(workflow): enforce readonly token in action workflow.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,9 @@ name: CI
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
the github action workflow does not enforce readonly token and this shows up as a security issue, see #52